### PR TITLE
bugfix: [Exercise 4.7] isolate inline conditional statements

### DIFF
--- a/exercises/Exercise4.7.py
+++ b/exercises/Exercise4.7.py
@@ -158,7 +158,7 @@ class PolicyIteration:
             if a > 0:
                 a -= 1
             cost = self.params.cost_per_car * abs(a) + self.params.cost_per_slot_night * (
-                1 if s_first > self.params.max_car / 2 else 0 + 1 if s_second > self.params.max_car / 2 else 0)
+                (1 if s_first > self.params.max_car / 2 else 0) + (1 if s_second > self.params.max_car / 2 else 0))
 
         # Compute for each possible new state: probability, reward, and value of the new state, then apply the formula
         sum_prob_i = 0


### PR DESCRIPTION
In Exercise 4.7, the authors pose a modified version of the car rental problem from Example 4.2. A part of the modified problem states that:

"_...In addition, Jack has limited parking space at each location. If more than 10 cars are kept overnight at a location (after any moving of cars), then an additional cost of $4 must be incurred to use a second parking lot (independent of how many cars are kept there)._".

This means, that if the number of cars exceeds 10 in both locations, **two** new parking-lots need to be used (one at each location). As a result, a parking-charge of $8 is incurred. However, in the current state of the code, this situation would incur a parking-charge of $4. I'm not sure if this is a bug, or was intended due to a different interpretation of the problem-statement.

In case it is the former, this pull-request fixes this issue.

See snippet below for a minimal example of the issue.

```python
cost_per_extra_parking_lot = 4
max_cars_per_lot = 10
cars_first = 12
cars_second = 12

# expected result
expected_n_extra_parking_lots = 2

# code in master
n_extra_parking_lots_incorrect = (1 if cars_first > max_cars_per_lot else 0 + 1 if cars_second > max_cars_per_lot else 0)

# correct code
n_extra_parking_lots_correct = ((1 if cars_first > max_cars_per_lot else 0) + (1 if cars_second > max_cars_per_lot else 0))

print(f"expected charge: ${expected_n_extra_parking_lots * cost_per_extra_parking_lot}"
      f"\ncurrent master: ${n_extra_parking_lots_incorrect * cost_per_extra_parking_lot}\n"
      f"after proposed change: ${n_extra_parking_lots_correct * cost_per_extra_parking_lot}")

```

Optimal policy and state-value-distribution for the modified case after proposed change:

![image](https://user-images.githubusercontent.com/9308158/175322168-04fbafd4-5de5-4e07-ae10-6dde9e87d236.png)

![image](https://user-images.githubusercontent.com/9308158/175321973-0f96fc24-dd58-4b80-8267-771cd25ce6f0.png)

